### PR TITLE
Update ValidationResult.cfc

### DIFF
--- a/modules/cbvalidation/models/result/ValidationResult.cfc
+++ b/modules/cbvalidation/models/result/ValidationResult.cfc
@@ -96,7 +96,7 @@ component accessors="true" implements="IValidationResult"{
 	* Get a new error object
 	*/
 	IValidationError function newError(struct properties){
-		return duplicate( errorTemplate ).configure(argumentCollection=arguments);
+		return duplicate( errorTemplate ).configure(argumentCollection=arguments.properties);
 	}
 
 	/**


### PR DESCRIPTION
The "newError" function was trying to send a structure containing the argumentCollection instead of the actual argumentCollection to the "configure" function