### PR TITLE
Provide explicit name for interface implementation

### DIFF
--- a/modules/cbvalidation/models/result/ValidationResult.cfc
+++ b/modules/cbvalidation/models/result/ValidationResult.cfc
@@ -6,7 +6,7 @@ www.coldbox.org | www.luismajano.com | www.ortussolutions.com
 The ColdBox validation results
 */
 import cbvalidation.models.result.*;
-component accessors="true" implements="IValidationResult"{
+component accessors="true" implements="cbvalidation.models.result.IValidationResult"{
 
 	/**
 	* A collection of error objects represented in this result object


### PR DESCRIPTION
There was an exception being thrown in the validation module when running with the latest stable release of Lucee. Seems that the component wouldn't identify itself as implementing the interface when instances were passed as arguments. Changing the path to the module appears to fix it.