### PR TITLE
Default empty string for targetValue

### DIFF
--- a/modules/cbvalidation/models/validators/SizeValidator.cfc
+++ b/modules/cbvalidation/models/validators/SizeValidator.cfc
@@ -22,7 +22,7 @@ component accessors="true" implements="cbvalidation.models.validators.IValidator
 	* @targetValue.hint The target value to validate
 	* @validationData.hint The validation data the validator was created with
 	*/
-	boolean function validate(required cbvalidation.models.result.IValidationResult validationResult, required any target, required string field, any targetValue, any validationData){
+	boolean function validate(required cbvalidation.models.result.IValidationResult validationResult, required any target, required string field, any targetValue="", any validationData){
 		// check
 		if( !isValid("string",arguments.validationData) || !isValid("regex",arguments.validationData,"(\-?\d)+(?:\.\.\-?\d+)?")){
 			throw(message="The Required validator data needs to be boolean and you sent in: #arguments.validationData#",type="RequiredValidator.InvalidValidationData");


### PR DESCRIPTION
The SizeValidator does not allow you to do "0..{max}" constraints. When you populate a bean (using ORM for example) that has a constraint example of size "0..50", and the actual value in the database is NULL, the targetValue in the function is shown as "undefined". This leads to the validation always not passing and returning the error for required size. A default of "" in the arguments, not only allows the validation to properly work, but it also allows you to do stuff like:
"address"  : {
     type = "string",
     size = "0..50"
}